### PR TITLE
[OPPO-2165] B: revert app store and locale after creating pdf(s)

### DIFF
--- a/app/code/community/FireGento/Pdf/Model/Engine/Creditmemo/Default.php
+++ b/app/code/community/FireGento/Pdf/Model/Engine/Creditmemo/Default.php
@@ -60,10 +60,15 @@ class FireGento_Pdf_Model_Engine_Creditmemo_Default extends FireGento_Pdf_Model_
         // pagecounter is 0 at the beginning, because it is incremented in newPage()
         $this->pagecounter = 0;
 
+        $originalStore = Mage::app()->getStore();
+        $emulatedStore = false;
+
         foreach ($creditmemos as $creditmemo) {
             if ($creditmemo->getStoreId()) {
                 Mage::app()->getLocale()->emulate($creditmemo->getStoreId());
                 Mage::app()->setCurrentStore($creditmemo->getStoreId());
+
+                $emulatedStore = true;
             }
             $page = $this->newPage();
 
@@ -121,9 +126,11 @@ class FireGento_Pdf_Model_Engine_Creditmemo_Default extends FireGento_Pdf_Model_
 
         $this->_afterGetPdf();
 
-        if ($creditmemo->getStoreId()) {
+        if ($emulatedStore === true) {
             Mage::app()->getLocale()->revert();
+            Mage::app()->setCurrentStore($originalStore);
         }
+
         return $pdf;
     }
 

--- a/app/code/community/FireGento/Pdf/Model/Engine/Invoice/Default.php
+++ b/app/code/community/FireGento/Pdf/Model/Engine/Invoice/Default.php
@@ -60,10 +60,15 @@ class FireGento_Pdf_Model_Engine_Invoice_Default extends FireGento_Pdf_Model_Eng
         // pagecounter is 0 at the beginning, because it is incremented in newPage()
         $this->pagecounter = 0;
 
+        $originalStore = Mage::app()->getStore();
+        $emulatedStore = false;
+
         foreach ($invoices as $invoice) {
             if ($invoice->getStoreId()) {
                 Mage::app()->getLocale()->emulate($invoice->getStoreId());
                 Mage::app()->setCurrentStore($invoice->getStoreId());
+
+                $emulatedStore = true;
             }
             $page = $this->newPage();
 
@@ -130,6 +135,11 @@ class FireGento_Pdf_Model_Engine_Invoice_Default extends FireGento_Pdf_Model_Eng
         }
 
         $this->_afterGetPdf();
+
+        if ($emulatedStore === true) {
+            Mage::app()->getLocale()->revert();
+            Mage::app()->setCurrentStore($originalStore);
+        }
 
         return $pdf;
     }

--- a/app/code/community/FireGento/Pdf/Model/Engine/Shipment/Default.php
+++ b/app/code/community/FireGento/Pdf/Model/Engine/Shipment/Default.php
@@ -60,10 +60,15 @@ class FireGento_Pdf_Model_Engine_Shipment_Default extends FireGento_Pdf_Model_En
         // pagecounter is 0 at the beginning, because it is incremented in newPage()
         $this->pagecounter = 0;
 
+        $originalStore = Mage::app()->getStore();
+        $emulatedStore = false;
+
         foreach ($shipments as $shipment) {
             if ($shipment->getStoreId()) {
                 Mage::app()->getLocale()->emulate($shipment->getStoreId());
                 Mage::app()->setCurrentStore($shipment->getStoreId());
+
+                $emulatedStore = true;
             }
             $page = $this->newPage();
 
@@ -117,6 +122,11 @@ class FireGento_Pdf_Model_Engine_Shipment_Default extends FireGento_Pdf_Model_En
         }
 
         $this->_afterGetPdf();
+
+        if ($emulatedStore === true) {
+            Mage::app()->getLocale()->revert();
+            Mage::app()->setCurrentStore($originalStore);
+        }
 
         return $pdf;
     }


### PR DESCRIPTION
This caused a problem where e-mail’s had the wrong fallback when a PDF was attached. Becuase the store was set before the creation off the PDF the whole email template fallback was disrupted i.c.m. with Yireo_EmailOverride

Kudos to Jeroen